### PR TITLE
Version 23

### DIFF
--- a/src/finish.hbs
+++ b/src/finish.hbs
@@ -5,6 +5,6 @@
          <p>Thank you for participating! Please click <kbd>Next</kbd> to view the debriefing sheet.</p>
     </div>
     <div class="button-container">
-        <button class="btn btn-primary" id="finish-button">Next</button>
+        <button class="btn btn-primary" id="next-button">Next</button>
     </div>
 </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,6 +101,9 @@ var keypressAllowed: boolean = false;
 // set trial number
 var trialNumber: number = 0;
 
+// set absent counter
+var absentCount: number = 0;
+
 // block counter and number of blocks for block title
 var blockCounter: number = 0;
 const nBlocks: number = stimConditions.length;
@@ -610,6 +613,8 @@ gorilla.ready(function(){
 				console.log("The random trial number is " + randTrial);
 				console.log("If this number is not zero mod " + utils.moduloVal + " then it should be a target")
 				if (randTrial % utils.moduloVal == 0) {
+				    // increment absent counter
+				    absentCount++;
 					// generate a list of 25 random distractors
 					// Construct 25 random distractor urls
 					const randomDistractors: string[] = utils.generateDistractorArray(utils.nImagesInGrid);
@@ -622,6 +627,7 @@ gorilla.ready(function(){
 				    trialStruct.humanReadableTrialArray = randomDistractors;
 					trialStruct.isPresent = false;
 					trialStruct.isPresentString = 'absent';
+					trialStruct.targetImg = 'absent' + absentCount;
 				} else {
 					// choose from list of targets and append to the 24 distractor images
 					// Construct 24 random distractor urls
@@ -845,7 +851,7 @@ gorilla.ready(function(){
 		onEnter: (machine: stateMachine.Machine) => {
 			gorilla.populate('#gorilla', 'finish', {});
 			gorilla.refreshLayout();
-			$('#finish-button').one('click', (event: JQueryEventObject) => {
+			$('#next-button').one('click', (event: JQueryEventObject) => {
 				gorilla.finish();
 			})
 		} // end onEnter


### PR DESCRIPTION
In this commit we:
  - [edit] Changed `targetImg` metric to show the absent trials uniquely (instead of `null`);
  - [edit] Shifted <kbd>Next</kbd> button down dynamically with the view height;
  - [edit] Made information text wider;
  - [edit] Changed finish message;
  - [bug] Fixed finish <kbd>Next</kbd> button;

Still to do:
- Add demographics state and record responses;
- ITI metric?
- Code cleanup (old comments, print statements, class &Implies; ID in HTML, etc.).