### PR TITLE
Version 24

### DIFF
--- a/src/Style.less
+++ b/src/Style.less
@@ -22,12 +22,12 @@
 
 .content-container {
     position: absolute;
-    width: 80%;
+    width: 100%;
     top: 30%;
     // top: 30vh; // 30% of the view height
     left: 50%;
     // left: 50vw; // 50% of the view width
-    font-size: 14pt;
+    font-size: 12pt;
     -moz-transform: translateX(-50%) translateY(-30%);
     -webkit-transform: translateX(-50%) translateY(-30%);
     transform: translateX(-50%) translateY(-30%);
@@ -40,15 +40,17 @@
     // top: 30vh; // 30% of the view height
     left: 50%;
     // left: 50vw; // 50% of the view width
-    font-size: 14pt;
+    font-size: 12pt;
     -moz-transform: translateX(-50%) translateY(-50%);
     -webkit-transform: translateX(-50%) translateY(-50%);
     transform: translateX(-50%) translateY(-50%);
 }
 
 .button-container {
+    // position: relative;
     position: absolute;
-    bottom: 10%;
+    bottom: 5%; // 10% of vertical height
+    // bottom: 0;
     left: 50%;
     // margin: auto;
     // width: 50%;
@@ -99,44 +101,25 @@
     height: 1.8cm;
 }
 
-/* Dropdown Button */
-.dropbtn {
-    background-color: #4CAF50;
-    color: white;
-    padding: 16px;
-    font-size: 16px;
-    border: none;
-}
-
-/* The container <div> - needed to position the dropdown content */
-.dropdown {
-    position: relative;
-    display: inline-block;
-}
-
-/* Dropdown Content (Hidden by Default) */
-.dropdown-content {
-    display: none;
+.form-error {
+    // position: relative;
     position: absolute;
-    background-color: #f1f1f1;
-    min-width: 160px;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-    z-index: 1;
+    bottom: 20vh; // 10% of vertical height
+    // bottom: 0;
+    left: 50%;
+    // float: inherit;
+    // margin: auto;
+    // width: 50%;
+    // margin: 0 auto;
+    // z-index: 10;
+    color: red;
+    -moz-transform: translateX(-50%);
+    -webkit-transform: translateX(-50%);
+    transform: translateX(-50%);
 }
 
-/* Links inside the dropdown */
-.dropdown-content a {
-    color: black;
-    padding: 12px 16px;
-    text-decoration: none;
-    display: block;
+.incomplete-message>form-error {
 }
 
-/* Change color of dropdown links on hover */
-.dropdown-content a:hover {background-color: #ddd;}
-
-/* Show the dropdown menu on hover */
-.dropdown:hover .dropdown-content {display: block;}
-
-/* Change the background color of the dropdown button when the dropdown content is shown */
-.dropdown:hover .dropbtn {background-color: #3e8e41;}
+.invalid-age>form-error {
+}

--- a/src/demographics.hbs
+++ b/src/demographics.hbs
@@ -1,19 +1,38 @@
 <div class="fullheight fullsize" style="position:relative;">
-    <div class="content-container">
-        <h1>Demographics</h1>
-        <div class="dropdown">
-            <button class="dropbtn">Dropdown</button>
-            <div class="dropdown-content">
-                <!-- <a href="#">Link 1.0</a> -->
-                <!-- <a href="#">Link 1.1</a> -->
-                <!-- <a href="#">Link 1.2</a> -->
-                <p>Female</p>
-                <p>Male</p>
-                <p>Other</p>
-            </div>
-        </div>
+    <div class="content-container" align="center">
+        <h1>Participant details</h1>
+        <form name="demographics-form" action="#" align="left">
+            <p class="form-box">
+                <label for="name">Name</label>
+                <input id="name" name="name">
+            </p>
+            <p class="form-box">
+                <label for="age">Age</label>
+                <input id="age" name="age">
+            </p>
+            <p class="form-box">
+                <label for="gender" title="Gender">Gender</label>
+                <select id="gender" name="gender">
+                    <optgroup label="Genders">
+                        <option value="undef" style="color: grey">(undefined)</option>
+                        <option value="male">Male</option>
+                        <option value="female">Female</option>
+                        <option value="other">Other</option>
+                    </optgroup>
+                </select>
+            </p>
+        </form>
     </div>
     <div class="button-container">
+        <!-- <button class="btn btn-primary response-button" id="next-button" data-response="Next">Next</button> -->
         <button class="btn btn-primary" id="next-button">Next</button>
+    </div>
+    <div class="form-error">
+        <div class="incomplete-message" hidden>
+            <p>Please fill in everything before continuing.</p>
+        </div>
+        <div class="invalid-age" hidden>
+            <p>Please enter a valid age!</p>
+        </div>
     </div>
 </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,6 +108,11 @@ var absentCount: number = 0;
 var blockCounter: number = 0;
 const nBlocks: number = stimConditions.length;
 
+// need demographics to be global
+var participantName: string;
+var participantGender: string;
+var participantAge: number;
+
 // // onclick for dropdown press
 // window.onclick = function(event) {
 // 	if (!event.target.matches('.dropbtn')) {
@@ -162,15 +167,15 @@ gorilla.ready(function(){
 			    if(!utils.isFullscreen()){
                     utils.launchIntoFullscreen(document.documentElement);
                 }
-				// machine.transition(State.Demographics);
-				machine.transition(State.Instructions);
+				machine.transition(State.Demographics);
+				// machine.transition(State.Instructions);
 			}) // end on keypress
 			$(document).one('keypress', (event: JQueryEventObject) => {
 			    if(!utils.isFullscreen()){
                     utils.launchIntoFullscreen(document.documentElement);
                 }
-				// machine.transition(State.Demographics);
-				machine.transition(State.Instructions);
+				machine.transition(State.Demographics);
+				// machine.transition(State.Instructions);
 			}) // end on keypress
 		} // end onEnter
 	}) // end addState State.Consent
@@ -180,17 +185,69 @@ gorilla.ready(function(){
 		  //  var elem = document.body; // Make the body go full screen.
             // requestFullScreen(elem);
             
-			gorilla.populate('#gorilla', 'demographics', {})
+			// gorilla.populate('#gorilla', 'demographics', {})
+			// gorilla.refreshLayout();
+			
+			$(document).off('keypress');
+			
+			$('.incomplete-message').hide();
+			$('.invalid-age').hide();
 			gorilla.refreshLayout();
+			gorilla.populate('#gorilla', 'demographics', {})
 			
-			// $('#dropdown').one('click', (event: JQueryEventObject) => {
-			// 	utils.toggleDropdown();
-			// }) // end on dropdown press
+			// gorilla.populateAndLoad($('#gorilla'), 'demographics', {}, (err) => {
 			
-			$('#next-button').one('click', (event: JQueryEventObject) => {
+				// $('#dropdown').one('click', (event: JQueryEventObject) => {
+				// 	utils.toggleDropdown();
+				// }) // end on dropdown press
+				
+				$('#next-button').on('click', (event: JQueryEventObject) => {
+					participantGender = (<HTMLInputElement>document.getElementById("gender")).value;
+					participantName = (<HTMLInputElement>document.getElementById("name")).value;
+					var rawAge = (<HTMLInputElement>document.getElementById("age")).value;
+					console.log(participantGender);
+					if (participantName == "" || rawAge == "" || participantGender === "undef") {
+						$('.invalid-age').hide();
+						$('.incomplete-message').show();
+					} else {
+						var intAge = parseInt(rawAge);
+						if (isNaN(intAge)) {
+							// tell them to enter a valid age
+							// machine.transition(State.Demographics);
+							$('.incomplete-message').hide();
+							$('.invalid-age').show();
+							// gorilla.refreshLayout();
+						} else {
+							// we have a valid integer and it's chill
+							$('.invalid-age').hide();
+							$('.incomplete-message').hide();
+							participantAge = intAge;
+							machine.transition(State.Instructions);
+						}
+					}
+					// participantAge = (<HTMLInputElement>document.getElementById("age")).value;
+					// machine.transition(State.Instructions);
+				}) // end on click
+			
+			// }); // end populateAndLoad
+		}, // end onEnter
+		
+		/*
+		onExit: (machine: stateMachine.Machine) => {
+		    participantGender = (<HTMLInputElement>document.getElementById("gender")).value;
+			participantName = (<HTMLInputElement>document.getElementById("name")).value;
+			intAge = parseInt((<HTMLInputElement>document.getElementById("age")).value);
+			if (isNaN(intAge)) {
+				// tell them to enter a valid age
+				machine.transition(State.Demographics);
+			} else {
+				// we have a valid integer and it's chill
+				participantAge = intAge;
 				machine.transition(State.Instructions);
-			}) // end on click
-		} // end onEnter
+			}
+			// participantAge = (<HTMLInputElement>document.getElementById("age")).value;
+		} // end onExit
+		*/
 	}) // end addState State.Consent
 
 	// In this state we will display our instructions for the task
@@ -778,6 +835,9 @@ gorilla.ready(function(){
 						response_time:  informationStruct.trialStruct.responseTime, // response time
 						timed_out: informationStruct.trialStruct.timedOut,
 						trial_array: informationStruct.trialStruct.humanReadableTrialArray,
+						age: participantAge,
+						name: participantName,
+						gender: participantGender,
 					}); // end metric
 
 					// move on transition
@@ -822,6 +882,9 @@ gorilla.ready(function(){
 						response_time: null, // response timeout
 						timed_out: true,
 						trial_array: informationStruct.trialStruct.humanReadableTrialArray,
+						age: participantAge,
+						name: participantName,
+						gender: participantGender,
 					});// end metric
 					
 					$('#gorilla')


### PR DESCRIPTION
This is the first ready-for-release version, as it contains demographics collection before the practice trials and actual blocks.  This code contains states for consent and debrief forms, but they are never accessed at this point (as these steps are currently handled by @collyeeliz).

In this commit we:
  - [edit] Shifted the <kbd>Next</kbd> button down;
  - [edit] Made content text smaller (changed to 12pt);
  - [feature] Added demographics state and recorded them as metrics (including having error messages for invalid demographics).

Still to do:
  - Make the next button better (more dynamic);
  - ITI metric?
  - Code cleanup (old comments, print statements, class &Implies; ID in HTML, etc.).